### PR TITLE
Add basic integration test structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .rts2_cache*
 .idea
 dist/
+.test-space/
 node_modules/
 
 # temporary ignored during raid => choose one to keep afterwards

--- a/__tests__/cli.ts
+++ b/__tests__/cli.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import path from 'path';
+import util from 'util';
+import childProcess from 'child_process';
+
+const mkdir = util.promisify(fs.mkdir);
+const rmdir = util.promisify(fs.rmdir);
+const writeFile = util.promisify(fs.writeFile);
+
+function exec(
+  command: string,
+  options: { cwd: string },
+): Promise<{ exitCode: number | null; stdout: string }> {
+  return new Promise((resolve) => {
+    const process = childProcess.exec(command, options, (_error, stdout) => {
+      resolve({ exitCode: process.exitCode, stdout });
+    });
+  });
+}
+
+const projectFixture = [
+  { name: 'package.json', content: '{ "main": "index.js" }' },
+  { name: 'index.js', content: `import foo from './foo';` },
+  { name: 'foo.js', content: '' },
+  { name: 'bar.js', content: '' },
+];
+
+async function createProject(
+  files: Array<{ name: string; content: string }>,
+): Promise<string> {
+  const randomId = Math.floor(Math.random() * 1000000);
+
+  const testSpaceDir = path.join('.test-space', randomId.toString());
+
+  await mkdir(testSpaceDir, { recursive: true });
+
+  await Promise.all(
+    files.map((file) =>
+      writeFile(path.join(testSpaceDir, file.name), file.content),
+    ),
+  );
+
+  return testSpaceDir;
+}
+
+let testProjectDir: string, executable: string;
+
+beforeEach(async () => {
+  testProjectDir = await createProject(projectFixture);
+  executable = path.join(path.relative(testProjectDir, 'bin'), 'unimported.js');
+});
+
+afterEach(() => rmdir(testProjectDir, { recursive: true }));
+
+test('should identify unimported file', async () => {
+  const { exitCode, stdout } = await exec(`node ${executable}`, {
+    cwd: testProjectDir,
+  });
+
+  expect(exitCode).not.toBe(0);
+  expect(stdout).toEqual(expect.stringContaining('1 unimported files'));
+  expect(stdout).toEqual(expect.stringContaining('bar.js'));
+});

--- a/__tests__/cli.ts
+++ b/__tests__/cli.ts
@@ -51,7 +51,7 @@ const scenarios = [
 ];
 
 describe('cli integration tests', () => {
-  for (const scenario of scenarios) {
+  scenarios.forEach((scenario) => {
     test(scenario.description, async () => {
       const testProjectDir = await createProject(scenario.files);
       const executable = path.join(
@@ -72,5 +72,5 @@ describe('cli integration tests', () => {
         await rmdir(testProjectDir, { recursive: true });
       }
     });
-  }
+  });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  modulePathIgnorePatterns: ['<rootDir>/.test-space/*']
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  modulePathIgnorePatterns: ['<rootDir>/.test-space/*']
+  modulePathIgnorePatterns: ['<rootDir>/.test-space/*'],
 };


### PR DESCRIPTION
This change introduces a structure for running integration test cases against generated projects to test specific scenarios.

New cases can be added by adding more scenario descriptors to the `scenarios` array:

```ts
const scenarios = [
  {
    description: 'should identify unimported file',
    files: [
      { name: 'package.json', content: '{ "main": "index.js" }' },
      { name: 'index.js', content: `import foo from './foo';` },
      { name: 'foo.js', content: '' },
      { name: 'bar.js', content: '' },
    ],
    exitCode: 1,
    output: ['1 unimported files', 'bar.js'],
  },
];
```

The test will generate all the listed `files`, execute `bin/unimported.js` against that directory, check the `exitCode` matches and the output contains all the listed strings in `output.

I think this array may get large over time. To mitigate this, I would have liked to have the a `fixtures` directory that had a file per scenario that just exported the values and have the test iterate those files instead of the array, but it's late and I wanted to start getting some feedback on this before I go too far.  It might have been a bit of overkill to go that far if we only end up with a few scenarios to run.

Feedback welcome and feel free to pick this up and push more changes if you have any good ideas.