### PR TITLE
Test CLI output when there is an unused dependency

### DIFF
--- a/__tests__/cli.ts
+++ b/__tests__/cli.ts
@@ -12,9 +12,12 @@ function exec(
   options: { cwd: string },
 ): Promise<{ exitCode: number | null; stdout: string }> {
   return new Promise((resolve) => {
-    const process = childProcess.exec(command, options, (_error, stdout) => {
-      resolve({ exitCode: process.exitCode, stdout });
-    });
+    try {
+      const buffer = childProcess.execSync(command, options);
+      resolve({ exitCode: 0, stdout: buffer.toString() });
+    } catch (ex) {
+      resolve({ exitCode: ex.status, stdout: ex.stdout.toString() });
+    }
   });
 }
 
@@ -60,7 +63,7 @@ describe('cli integration tests', () => {
       );
 
       try {
-        const { exitCode, stdout } = await exec(`node ${executable}`, {
+        const { stdout, exitCode } = await exec(`node ${executable}`, {
           cwd: testProjectDir,
         });
 

--- a/__tests__/cli.ts
+++ b/__tests__/cli.ts
@@ -51,6 +51,20 @@ const scenarios = [
     exitCode: 1,
     output: ['1 unimported files', 'bar.js'],
   },
+  {
+    description: 'should identify unused dependencies',
+    files: [
+      {
+        name: 'package.json',
+        content:
+          '{ "main": "index.js", "dependencies": { "@test/dependency": "1.0.0" } }',
+      },
+      { name: 'index.js', content: `import foo from './foo';` },
+      { name: 'foo.js', content: '' },
+    ],
+    exitCode: 1,
+    output: ['1 unused dependencies', '@test/dependency'],
+  },
 ];
 
 describe('cli integration tests', () => {


### PR DESCRIPTION
Fixes #23 

Replaces `childProcess.exec` in `cli.ts` with `childProcess.execSync` which is wrapped in a `try..catch`. 
The previous implementation was throwing an error `Property 'exitCode' does not exist on type 'ChildProcess'.` 
There might be other ways to fix this so comments are welcomed.