### PR TITLE
test: force locale to english

### DIFF
--- a/src/__tests__/help.ts
+++ b/src/__tests__/help.ts
@@ -4,7 +4,9 @@ const exec = util.promisify(require('child_process').exec);
 
 test('npx unimported --help', async () => {
   // note about `./` path: jest executes the tests from the root directory
-  const { stdout, stderr } = await exec('ts-node src/index.ts --help');
+  const { stdout, stderr } = await exec(
+    `LC_ALL='en' ts-node src/index.ts --help`,
+  );
 
   expect(stderr).toBe('');
   expect(stdout.trim()).toMatchInlineSnapshot(`


### PR DESCRIPTION
Because  I'm using another language on my OS the test are failing because `yargs` is using the local language. I have forced for tests the English language 