### PR TITLE
test: improve cli coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 .test-space/
 coverage/
 node_modules/
+.DS_Store
 
 # temporary ignored during raid => choose one to keep afterwards
 package-lock.json


### PR DESCRIPTION
Fixes #31 (screenshots of coverage before/after in the issue).

Checking exitCode *after* checking stdout, to get some useful message if it fails (`0 != 1` was not very useful).