### PR TITLE
refactor: run cli tests in the same process to improve test coverage reporting

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,9 +1,0 @@
-{
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": true,
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/__tests__/**", "**/__mocks__/**"],
-  "reporter": ["lcov", "text"],
-  "tempDirectory": "./coverage"
-}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  roots: ['<rootDir>/src'],
   modulePathIgnorePatterns: ['<rootDir>/.test-space/*'],
   collectCoverageFrom: ['<rootDir>/**/*.ts', '!<rootDir>/node_modules/'],
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepublish": "npm run build",
     "run": "npm run build && node ./dist/index.js",
     "test": "jest",
-    "test:cov": "nyc --clean npm run test",
+    "test:cov": "npm run test -- --coverage",
     "ci:lint": "eslint -c ./.eslintrc.js",
     "ci:tsc": "tsc --noEmit --project ./tsconfig.json"
   },
@@ -49,7 +49,6 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/glob": "^7.1.1",
     "@types/jest": "^26.0.20",
     "@types/node": "^13.13.2",
@@ -62,7 +61,6 @@
     "jest": "^26.6.3",
     "lint-staged": "^10.1.7",
     "nodemon": "^2.0.3",
-    "nyc": "^15.1.0",
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export interface Context {
   moduleDirectory: string[];
 }
 
-async function main(args: CliArguments) {
+export async function main(args: CliArguments) {
   const spinner = ora('initializing').start();
   const cwd = process.cwd();
 
@@ -160,7 +160,7 @@ async function main(args: CliArguments) {
   }
 }
 
-interface CliArguments {
+export interface CliArguments {
   flow: boolean;
   update: boolean;
   init: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export interface Context {
   moduleDirectory: string[];
 }
 
-export async function main(args: CliArguments) {
+export async function main(args: CliArguments): Promise<void> {
   const spinner = ora('initializing').start();
   const cwd = process.cwd();
 


### PR DESCRIPTION
This is the hacky fix for the coverage reporting I was talking about in discord.  I'm not proud of this code (maybe a little).

I'll put comments on the files where I think there are things worth noting.

I'll mark this a draft until there is a bit more feedback on the approach.  Personally, I feel like this code is high on the cringe factor, but interested to hear what @smeijer thinks (I can't request a review from him here, probably because he hasn't interacted with this fork before).

For reference, these changes produce the following coverage report (at time of writing):

```txt
----------------|---------|----------|---------|---------|--------------------------------------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                
----------------|---------|----------|---------|---------|--------------------------------------------------
All files       |   83.33 |    65.82 |   91.67 |   83.04 |                                                  
 config.ts      |     100 |      100 |     100 |     100 |                                                  
 ensureArray.ts |     100 |      100 |     100 |     100 |                                                  
 fs.ts          |   90.91 |       40 |     100 |   90.63 | 19,31,55                                         
 index.ts       |   84.91 |    76.92 |     100 |   84.91 | 81,118-120,156-159                               
 meta.ts        |   65.52 |    48.08 |   77.78 |   64.91 | 11,32-35,41-50,66,81,98,111,115-132,157          
 print.ts       |     100 |    91.67 |     100 |     100 | 34                                               
 process.ts     |   81.25 |      100 |      75 |   81.25 | 13-14,28                                         
 traverse.ts    |   82.35 |    70.83 |     100 |   81.93 | 33,44,98-100,166,182,194,229,234,242-244,253-254 
----------------|---------|----------|---------|---------|--------------------------------------------------

Test Suites: 4 passed, 4 total
Tests:       12 passed, 12 total
Snapshots:   3 passed, 3 total
Time:        3.469 s
```