### PR TITLE
chore(package.json): change prepublish to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "rimraf ./dist && tsc",
     "lint": "tsc --noEmit && eslint 'src/**/*.ts' --quiet --fix",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "run": "npm run build && node ./dist/index.js",
     "test": "jest",
     "test:cov": "npm run test -- --coverage",


### PR DESCRIPTION
prepublish is being deprecated in favor or prepare,
merge this if the main maintainers are ok with it