### PR TITLE
test(cli): Add monorepo tests

### DIFF
--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -153,6 +153,21 @@ export default promise
       exitCode: 0,
       stdout: /There don't seem to be any unimported files./,
     },
+    {
+      description: 'should identify ts paths imports',
+      files: [
+        { name: 'package.json', content: '{ "main": "index.ts" }' },
+        { name: 'index.ts', content: `import foo from '@root/foo';` },
+        { name: 'foo.ts', content: '' },
+        { name: 'bar.ts', content: '' },
+        {
+          name: 'tsconfig.json',
+          content: '{ "compilerOptions": { "paths": { "@root": ["."] } } }',
+        },
+      ],
+      exitCode: 1,
+      stdout: /1 unimported files.*bar.ts/s,
+    },
   ];
 
   scenarios.forEach((scenario) => {

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -206,7 +206,6 @@ export default promise
         scenario.baseDir,
       );
 
-      console.log(testProjectDir);
       try {
         const { stdout, stderr, exitCode } = await exec(testProjectDir);
 

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -60,7 +60,6 @@ async function exec(
 
 async function createProject(
   files: Array<{ name: string; content: string }>,
-  directories: string[] = [],
   baseDir = '.',
 ): Promise<string> {
   const randomId = Math.floor(Math.random() * 1000000);
@@ -70,8 +69,10 @@ async function createProject(
   await mkdir(testSpaceDir, { recursive: true });
 
   await Promise.all(
-    directories.map((dir) =>
-      mkdir(path.join(testSpaceDir, dir), { recursive: true }),
+    files.map((file) =>
+      mkdir(path.join(testSpaceDir, path.dirname(file.name)), {
+        recursive: true,
+      }),
     ),
   );
 
@@ -178,7 +179,6 @@ export default promise
     },
     {
       description: 'should identify monorepo-type sibling modules',
-      directories: ['packages/A', 'packages/B', 'packages/C'],
       baseDir: 'packages/A',
       files: [
         {
@@ -202,7 +202,6 @@ export default promise
     test(scenario.description, async () => {
       const testProjectDir = await createProject(
         scenario.files,
-        scenario.directories,
         scenario.baseDir,
       );
 


### PR DESCRIPTION
closes: #36

testing the ts paths one was pretty easy, but for the monorepo support I had to innovate.
add optional directories argument to create directories
add optional baseDir to change the base dir to something else.

names used in tests either corresponds to names used in implementation code, or generic placeholder / foobarbaz names