### PR TITLE
Remove need to change isolatedModules: false for tests

### DIFF
--- a/src/__mocks__/term-size.ts
+++ b/src/__mocks__/term-size.ts
@@ -2,4 +2,4 @@ const result = {
   columns: 80,
 };
 
-module.exports = jest.fn(() => result);
+export default jest.fn(() => result);

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
-import { CliArguments } from '..';
+import { main, CliArguments } from '..';
 
 const mkdir = util.promisify(fs.mkdir);
 const rmdir = util.promisify(fs.rmdir);
@@ -43,8 +43,6 @@ async function exec(
     };
 
     process.chdir(testProjectDir);
-
-    const main = require('..').main as (args: CliArguments) => Promise<void>;
 
     await main({ init, flow, update });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "outDir": "./dist",
-    "isolatedModules": false,
+    "isolatedModules": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,


### PR DESCRIPTION
In reference to [this comment](https://github.com/smeijer/unimported/pull/17/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.md&file-filters%5B%5D=.ts&file-filters%5B%5D=.yml#r568183504).

Updated tests to not need `isolatedModules` disabled in order to run.